### PR TITLE
Show TSLint in "Linter/Formatter" when TypeScript selected

### DIFF
--- a/packages/cli/lib/init.js
+++ b/packages/cli/lib/init.js
@@ -101,10 +101,7 @@ module.exports = function (type, dir, opts) {
 			name: 'linter',
 			message: '(TODO) Which linter / formatter do you like?',
 			type: (_, all) => all.features.some(x => /linter-or-formatter/.test(x) || /typescript/.test(x)) && 'select',
-			choices: val => toChoices((!/typescript/.test(val) || /linter-or-formatter/.test(val)
-				? ['None', 'ESLint', 'Prettier']
-				: [])
-				.concat(['TSLint'])),
+			choices: val => toChoices((/linter-or-formatter/.test(val) ? ['None', 'ESLint', 'Prettier']	: []).concat(['TSLint'])),
 			format: val => val !== 'none' && val
 		}, {
 			name: 'sw',

--- a/packages/cli/lib/init.js
+++ b/packages/cli/lib/init.js
@@ -100,8 +100,11 @@ module.exports = function (type, dir, opts) {
 		}, {
 			name: 'linter',
 			message: '(TODO) Which linter / formatter do you like?',
-			type: (_, all) => all.features.some(x => /linter-or-formatter/.test(x)) && 'select',
-			choices: toChoices(['None', 'ESLint', 'Prettier', 'TSLint']),
+			type: (_, all) => all.features.some(x => /linter-or-formatter/.test(x) || /typescript/.test(x)) && 'select',
+			choices: val => toChoices((!/typescript/.test(val) || /linter-or-formatter/.test(val)
+				? ['None', 'ESLint', 'Prettier']
+				: [])
+				.concat(['TSLint'])),
 			format: val => val !== 'none' && val
 		}, {
 			name: 'sw',


### PR DESCRIPTION
My attempt to implement second point of #36.

As soon as "Linter/Formatter" feature is selected, all options are displayed (regardless of `TypeScript `selection). If `TypeScript `is selected but not the "Linter/Formatter", only `TSLint `option is proposed.

Hope that the logic is correct :grimacing:

Don't hesitate if you see any improvement :blush:

