### PR TITLE
Use existing Browserslist config files

### DIFF
--- a/packages/cli/lib/init.js
+++ b/packages/cli/lib/init.js
@@ -231,6 +231,10 @@ module.exports = function (type, dir, opts) {
 			pkg.devDependencies[str] = 'latest';
 		});
 
+		// Add "browserslist" key w/ defaults
+		// @see https://jamie.build/last-2-versions
+		pkg.browserslist = ['>0.25%', 'not ie 11', 'not op_mini all'];
+
 		// Scaffold new files in `dest` target
 		// ---
 

--- a/packages/core/config/index.js
+++ b/packages/core/config/index.js
@@ -41,5 +41,5 @@ exports.uglify = {
 	}
 }
 
-// Leave this commented out -- is visual docs
-// exports.webpack = function (config, opts) {}
+// Leave this commented out -- visual docs
+// exports.webpack = function (config, opts, env) {}

--- a/packages/core/config/index.js
+++ b/packages/core/config/index.js
@@ -20,13 +20,6 @@ exports.babel = {
 	]
 }
 
-// @see https://jamie.build/last-2-versions
-exports.browsers = [
-	'>0.25%',
-	'not ie 11',
-	'not op_mini all'
-]
-
 // Any PostCSS config
 // ~> "autoprefixer" will be replaced
 exports.postcss = {

--- a/packages/core/config/index.js
+++ b/packages/core/config/index.js
@@ -7,7 +7,6 @@ exports.babel = {
 			modules: false,
 			targets: {
 				uglify: true,
-				// "browsers" are injected
 			},
 			exclude: [
 				'transform-regenerator',

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -15,6 +15,9 @@ module.exports = function (src, opts) {
 	let config = require('./config');
 	let tmp, customs=[], handlers=[];
 
+	// Share parsed `browerslist` globally
+	opts.browsers = require('browerslist')();
+
 	// Parse configs from local "package.json"
 	if (tmp = $.load('package.json', cwd)) {
 		let devs = Object.keys(tmp.devDependencies || {});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "@pwa/webpack-assets": "^0.1.0",
     "autoprefixer": "^8.6.4",
     "babel-loader": "^8.0.2",
+    "browserslist": "^4.2.0",
     "css-loader": "^0.28.11",
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^3.2.0",

--- a/packages/core/webpack/index.js
+++ b/packages/core/webpack/index.js
@@ -28,7 +28,7 @@ module.exports = function (src, config, opts) {
 	});
 
 	// Construct Style rules
-	let styles = require('./style')(browsers, postcss, opts);
+	let styles = require('./style')(postcss, opts);
 
 	if (!isProd) {
 		bundle.push(

--- a/packages/core/webpack/index.js
+++ b/packages/core/webpack/index.js
@@ -6,7 +6,7 @@ const HTML = require('html-webpack-plugin');
 const toHTMLConfig = require('./html');
 
 module.exports = function (src, config, opts) {
-	const webpack = opts.webpack;
+	const { cwd, webpack } = opts;
 	opts.log = opts.log || console;
 
 	let isProd = opts.production;
@@ -40,7 +40,7 @@ module.exports = function (src, config, opts) {
 		entry: { bundle },
 		output: {
 			publicPath: '/',
-			path: join(opts.cwd, opts.dest || 'build'),
+			path: join(cwd, opts.dest || 'build'),
 			filename: isProd ? '[name].[hash:8].js' : '[name].js',
 			chunkFilename: isProd ? '[name].chunk.[chunkhash:5].js' : '[name].chunk.js'
 		},
@@ -111,8 +111,8 @@ module.exports = function (src, config, opts) {
 			disableHostCheck: true,
 			watchOptions: {
 				ignored: [
-					join(opts.cwd, 'build'),
-					join(opts.cwd, 'node_modules')
+					join(cwd, 'build'),
+					join(cwd, 'node_modules')
 				]
 			}
 		}

--- a/packages/core/webpack/index.js
+++ b/packages/core/webpack/index.js
@@ -12,17 +12,15 @@ module.exports = function (src, config, opts) {
 	let isProd = opts.production;
 	let bundle = ['./index.js'];
 
-	let { babel, browsers, postcss, uglify } = config;
+	let { babel, postcss, uglify } = config;
 	let extns = ['.wasm', '.mjs', '.js', '.json']; // webpack defaults
 
-	// Apply "browserlist" to Babel config
+	// Customize "targets.browsers" w/ ESM warning
 	babel.presets = babel.presets.map(x => {
 		if (!Array.isArray(x) || x[0] !== '@babel/preset-env') return x;
 		let tars = x[1].targets;
-		if (tars && tars.esmodules) {
-			opts.log.warn('Babel ignores `browsers` when `esmodules` are targeted');
-		} else {
-			x[1].targets = Object.assign({ browsers }, x[1].targets);
+		if (tars && tars.esmodules && tars.browsers) {
+			opts.log.warn('Babel ignores custom `browsers` when `esmodules` are targeted');
 		}
 		return x;
 	});

--- a/packages/core/webpack/style.js
+++ b/packages/core/webpack/style.js
@@ -1,12 +1,16 @@
 const ExtractCSS = require('mini-css-extract-plugin');
-const { isEmpty } = require('../util');
 
 function generate(isProd, name, options) {
 	options.sourceMap = isProd;
 	return (name += '-loader') && { loader:name, options };
 }
 
-module.exports = function (browsers, postcss, opts) {
+module.exports = function (postcss, opts) {
+	// Throw if `postcss.plugin` is a fn
+	if (typeof postcss.plugins === 'function') {
+		throw new Error('Received unsupported `function` type for PostCSS "plugins" config');
+	}
+
 	let { src, production } = opts;
 	let fn = generate.bind(null, production);
 	let test, plugins=[], rules=[], paths=['node_modules'];
@@ -37,39 +41,11 @@ module.exports = function (browsers, postcss, opts) {
 		css.localIdentName = '[hash:base64:5]';
 	}
 
-	plugins.push( new ExtractCSS({ filename, chunkFilename }) );
+	plugins.push(
+		new ExtractCSS({ filename, chunkFilename })
+	);
 
-	// PostCSS ~> Array, apply browserlist
-	let k, had, tmp=postcss.plugins, pfx='autoprefixer';
-	postcss.plugins = [];
-
-	if (typeof tmp === 'function') {
-		throw new Error('Received unsupported `function` type for PostCSS "plugins" config');
-	} else if (isEmpty(tmp)) {
-		postcss.plugins.push( require(pfx)({ browsers }) );
-	} else if (Array.isArray(tmp)) {
-		postcss.plugins = tmp.map(x => {
-			let type = typeof x;
-			if (type === 'string') {
-				had = had || x === pfx;
-				return require(x)(x === pfx ? { browsers } : {});
-			} else if (type === 'function') {
-				(x.postcssPlugin === pfx) && (had=true) && (x.browsers=browsers);
-				return x;
-			} else {
-				throw new Error(`Found unsupported type \`${type}\` in PostCSS "plugins" config`);
-			}
-		});
-	} else {
-		for (k in tmp) {
-			if (k === pfx) Object.assign(tmp[k], { browsers });
-			postcss.plugins.push( require(k)(tmp[k] || {}) );
-		}
-	}
-
-	had || postcss.plugins.push( require(pfx)({ browsers }) );
-	postcss = fn('postcss', postcss); // loader
-
+	postcss = fn('postcss', postcss); //=> loader
 	let user = [fallback, fn('css', css), postcss];
 	let vendor = [fallback, fn('css', { sourceMap:true }), postcss];
 

--- a/packages/plugin-buble/index.js
+++ b/packages/plugin-buble/index.js
@@ -7,7 +7,7 @@ exports.buble = {
 exports.webpack = function (config, env, opts) {
 	if (!opts.buble.target) {
 		let i=0, tar={}, key, ver;
-		let browsers = require('browserslist')(); // finds itself
+		let browsers = opts.browsers; // results
 		let supported = ['chrome', 'edge', 'ie', 'safari', 'firefox'];
 		for (; i < browsers.length; i++) {
 			[key, ver] = browsers[i].split(' ');

--- a/packages/plugin-buble/index.js
+++ b/packages/plugin-buble/index.js
@@ -7,7 +7,7 @@ exports.buble = {
 exports.webpack = function (config, env, opts) {
 	if (!opts.buble.target) {
 		let i=0, tar={}, key, ver;
-		let browsers = require('browserslist')(opts.browsers);
+		let browsers = require('browserslist')(); // finds itself
 		let supported = ['chrome', 'edge', 'ie', 'safari', 'firefox'];
 		for (; i < browsers.length; i++) {
 			[key, ver] = browsers[i].split(' ');

--- a/packages/plugin-buble/package.json
+++ b/packages/plugin-buble/package.json
@@ -8,7 +8,6 @@
     "node": ">=6"
   },
   "dependencies": {
-    "browserslist": "^4.1.1",
     "buble": "^0.19.3",
     "buble-loader": "^0.5.1"
   },

--- a/packages/plugin-buble/readme.md
+++ b/packages/plugin-buble/readme.md
@@ -20,7 +20,7 @@ The use of Bublé is recommended for simpler, vanilla JS applications... and/or 
 
 Configurable via the `buble` key on your `pwa.config.js` file.
 
-> **Note:** The [`browsers`](https://github.com/lukeed/pwa#browsers) list of your PWA config will be transformed into a `target` object for Bublé!<br>
+> **Note:** Your [`Browserslist config`](https://github.com/browserslist/browserslist#queries) results will be transformed into a `target` object for Bublé!<br>
 However, defining your own `buble.target` object will prevent this transformation.
 
 ***Default Config:***

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@
   _Includes a plugin system that allows for easy, fine-grain control of your configuration... when needed._
 
 * **Feature Rich**<br>
-  _Supports Babel, Bublé, Browserlist, TypeScript, PostCSS, ESLint, Prettier, and Service Workers out of the box!_
+  _Supports Babel, Bublé, Browserslist, TypeScript, PostCSS, ESLint, Prettier, and Service Workers out of the box!_
 
 * **Instant Prototyping**<br>
   _Quickly scaffold new projects with your preferred view library and toolkit.<br>Kick it off with a perfect Lighthouse score!_
@@ -309,6 +309,16 @@ Type: `Function`
 The main handler for ***all*** of PWA!<br>
 When you define a [custom](#customizing) `webpack`, you are not overriding this function. Instead, you are manipulating Webpack's config immediately before PWA executes the build.
 
+### Browserslist
+
+The preferred method for customizing your browser targets is thru the `browserslist` key within your `package.json` file.
+
+> **Note:** When creating a new project with `pwa init`, our recommended config is automatically added for you!
+
+You may choose to change the default values, or use [any configuration method that Browserslist accepts](https://github.com/browserslist/browserslist#queries).
+
+The resulting array of browser targets will be automatically applied to Autoprefixer, Babel, Bublé, PostCSS, Stylelint, ...etc.
+
 
 ### Customizing
 
@@ -325,9 +335,6 @@ Here is an example custom config file:
 ```js
 // pwa.config.js
 const OfflinePlugin = require('offline-plugin');
-
-// Override default browserlist
-exports.browsers = ['last 2 versions'];
 
 // Mutate "@pwa/plugin-eslint" config
 exports.eslint = function (config) {

--- a/readme.md
+++ b/readme.md
@@ -291,12 +291,6 @@ Default: [Link](https://github.com/lukeed/pwa/blob/master/packages/core/config/i
 
 Your Babel config object.
 
-#### `browsers`
-Type: `Array`<br>
-Default: [Link](https://github.com/lukeed/pwa/blob/master/packages/core/config/index.js#L24-L28)
-
-Your target [`browserlist`](https://github.com/browserslist/browserslist) &mdash; which is injected into PostCSS's [`autoprefixer`](https://github.com/postcss/autoprefixer) and Babel's [`env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) preset.
-
 #### `postcss`
 Type: `Array`<br>
 Default: [Link](https://github.com/lukeed/pwa/blob/master/packages/core/config/index.js#L32-L34)


### PR DESCRIPTION
Not as "clean" as I originally imagined, but this makes it a whole lot easier to integrate a core `config.browsers` list across the entire build. 

> AKA, can get rid of all the manual injections I was doing 😅🎉 

Relies on existing/conventional config locations, of which, `pwa init` will supply a `"browserslist"` key within new `package.json` files. Once `@pwa/core` starts up, it calls Browserslist immediately _just_ so that it has a copy of what all the other integrations will be using.

As of now, `plugin-buble` reads this copy & does its thing. I'm sure there will be others in the future.

---

_Closes #46_