### PR TITLE
fix(cli): Handle Chrome launch errors, upgrade chrome-launcher

### DIFF
--- a/packages/cli/lib/build.js
+++ b/packages/cli/lib/build.js
@@ -185,6 +185,8 @@ module.exports = function (src, opts) {
 							console.log('> error', err); // TODO
 						});
 					});
+				}).catch(err => {
+					log.bail(`Cannot launch Chrome: ${err.message}`);
 				});
 			});
 		}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@pwa/core": "^0.5.1",
-    "chrome-launcher": "^0.10.2",
+    "chrome-launcher": "^0.13.1",
     "chrome-remote-interface": "0.25.x",
     "kleur": "^3.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Fixes #72, also should fix Chrome launch in macOS Catalina.