### PR TITLE
Update @pwa/plugin-brotli [BREAKING CHANGE]

### DIFF
--- a/packages/plugin-brotli/index.js
+++ b/packages/plugin-brotli/index.js
@@ -8,8 +8,8 @@ exports.brotli = {
 	compressionOptions: {
 		params: {
 			[zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_GENERIC,
-    	[zlib.constants.BROTLI_PARAM_QUALITY]: 11,
-			[zlub.constants.BROTLI_PARAM_SIZE_HINT]: 0,
+			[zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+			[zlib.constants.BROTLI_PARAM_SIZE_HINT]: 0,
 			[zlib.constants.BROTLI_PARAM_LGBLOCK]: 0,
 			[zlib.constants.BROTLI_PARAM_LGWIN]: 22
 		}

--- a/packages/plugin-brotli/index.js
+++ b/packages/plugin-brotli/index.js
@@ -1,26 +1,28 @@
 const Compression = require('compression-webpack-plugin');
+const zlib = require('zlib');
 
 // @see https://github.com/webpack-contrib/compression-webpack-plugin#options
 exports.brotli = {
-	cache: true,
 	threshold: 0,
 	minRatio: 0.8,
 	compressionOptions: {
-		quality: 11,
-		size_hint: 0,
-		lgblock: 0,
-		lgwin: 22,
-		mode: 0
+		params: {
+			[zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_GENERIC,
+    	[zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+			[zlub.constants.BROTLI_PARAM_SIZE_HINT]: 0,
+			[zlib.constants.BROTLI_PARAM_LGBLOCK]: 0,
+			[zlib.constants.BROTLI_PARAM_LGWIN]: 22
+		}
 	}
 }
 
 exports.webpack = function (config, env, opts) {
 	if (env.production) {
 		opts.brotli.filename = '[path].br[query]';
-		opts.brotli.algorithm = require('iltorb').compress;
+		opts.brotli.algorithm = zlib.brotliCompress;
 
 		config.plugins.push(
 			new Compression(opts.brotli)
-		);
+		)
 	}
 }

--- a/packages/plugin-brotli/package.json
+++ b/packages/plugin-brotli/package.json
@@ -8,8 +8,7 @@
     "node": ">= 10.13.0"
   },
   "dependencies": {
-    "compression-webpack-plugin": "^7.0.0",
-    "iltorb": "^2.4.0"
+    "compression-webpack-plugin": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-brotli/package.json
+++ b/packages/plugin-brotli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@pwa/plugin-brotli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "files": [
     "index.js"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">= 10.13.0"
   },
   "dependencies": {
-    "compression-webpack-plugin": "^2.0.0",
+    "compression-webpack-plugin": "^7.0.0",
     "iltorb": "^2.4.0"
   },
   "publishConfig": {

--- a/packages/plugin-brotli/package.json
+++ b/packages/plugin-brotli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pwa/plugin-brotli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
**Requires Node v10.13+ and Webpack v5.1+**

* Updated `compression-webpack-plugin`, which has 2 vulnerabilities (1 moderate, 1 high)
* Replaced deprecated `iltorb` in favor of built-in `zlib` (support available since v10.16.0)